### PR TITLE
Change header for unsigned image

### DIFF
--- a/mboot.py
+++ b/mboot.py
@@ -205,6 +205,9 @@ def pack_bootimg_intel(fname):
     # add signature back to header if present
     if read('sig'):
         hdr += read_file('sig')
+    else:
+        imgType, = struct.unpack('I', hdr[52:56])
+        hdr = hdr[0:52] + struct.pack('I', imgType + 1) + hdr[56:]
 
     data = cmdline_block
     data += read_file('bootstub')


### PR DESCRIPTION
When pack image without signature (sig) the imgType should be changed.

0x00 for signed boot
0x01 for unsigned boot
0x0C for signed recovery
0x0D for unsigned recovery
0x0E for signed fastboot (provisioning)
0x0F for unsigned fastboot (provisioning)

reference: https://forum.xda-developers.com/showpost.php?p=69821039&postcount=33
Signed-off-by: Shaka Huang <shakalaca@gmail.com>