### PR TITLE
Fix error repacking unsigned image

### DIFF
--- a/mboot.py
+++ b/mboot.py
@@ -207,7 +207,7 @@ def pack_bootimg_intel(fname):
         hdr += read_file('sig')
     else:
         imgType, = struct.unpack('I', hdr[52:56])
-        hdr = hdr[0:52] + struct.pack('I', imgType + 1) + hdr[56:]
+        hdr = hdr[0:52] + struct.pack('I', imgType|0x01) + hdr[56:]
 
     data = cmdline_block
     data += read_file('bootstub')


### PR DESCRIPTION
For current known imgType bitwise OR 0x01 should be fine

0x00 for signed boot
0x01 for unsigned boot
0x0C for signed recovery
0x0D for unsigned recovery
0x0E for signed fastboot (provisioning)
0x0F for unsigned fastboot (provisioning)

Signed-off-by: Shaka Huang <shakalaca@gmail.com>